### PR TITLE
Add a Keyboard toggle for the Schema Pane

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,6 +29,8 @@ Tab completions are available for current context list indicies and key names.
 
 Use `CTRL-\` to toggle the focus between the Editor, Viewer, and Schema windows.
 
+Use `CTRL-S` to toggle the Schema window.
+
 Use `CTRL-Q` or `CTRL-C`to exit.
 
 > Note: Reserved key names that cannot be accessed using dot notation can be accessed via standard python dictionary notation. (e.g. `_.foo["get"]` instead of `_.foo.get`)

--- a/jellex/cli.py
+++ b/jellex/cli.py
@@ -15,7 +15,7 @@ from prompt_toolkit import Application
 from prompt_toolkit.formatted_text import to_formatted_text, HTML
 from prompt_toolkit.widgets import Frame, TextArea
 from prompt_toolkit.buffer import Buffer
-from prompt_toolkit.layout import ScrollablePane, Dimension
+from prompt_toolkit.layout import ScrollablePane, Dimension, ConditionalContainer
 from prompt_toolkit.layout.containers import VSplit, HSplit, Window
 from prompt_toolkit.layout.controls import BufferControl, FormattedTextControl
 from prompt_toolkit.layout.margins import NumberedMargin
@@ -24,6 +24,7 @@ from prompt_toolkit.completion import WordCompleter
 from prompt_toolkit.key_binding import KeyBindings
 from prompt_toolkit.key_binding.bindings.focus import focus_next
 from prompt_toolkit.lexers import PygmentsLexer
+from prompt_toolkit.filters import Condition
 
 
 parser = argparse.ArgumentParser(description='Interactive JSON Explorer using Python syntax.')
@@ -183,13 +184,26 @@ viewer = Frame(title='Viewer',
 
 # Schema Window
 schema_window = TextArea(text=last_output,
-                         height=5,
                          wrap_lines=False,
                          scrollbar=True,
                          focus_on_click=True,
                          lexer=PygmentsLexer(JavascriptLexer))
 schema = Frame(title='Schema',
                body=schema_window)
+
+show_schema = False
+
+
+@Condition
+def show_schema_window():
+    global show_schema
+    return show_schema
+
+
+@kb.add('c-s')
+def toggle_schema(event):
+    global show_schema
+    show_schema = not show_schema
 
 
 # Status Window
@@ -203,8 +217,12 @@ status = Frame(title='Status',
 # Main Screen
 root_container = HSplit(
     [
-        VSplit([editor, viewer]),
-        schema,
+        VSplit([editor,
+                HSplit([viewer,
+                        ConditionalContainer(schema, filter=show_schema_window)]
+                       )
+                ]
+               ),
         status
     ]
 )

--- a/jellex/cli.py
+++ b/jellex/cli.py
@@ -194,12 +194,6 @@ schema = Frame(title='Schema',
 show_schema = False
 
 
-@Condition
-def show_schema_window():
-    global show_schema
-    return show_schema
-
-
 @kb.add('c-s')
 def toggle_schema(event):
     global show_schema
@@ -219,7 +213,7 @@ root_container = HSplit(
     [
         VSplit([editor,
                 HSplit([viewer,
-                        ConditionalContainer(schema, filter=show_schema_window)]
+                        ConditionalContainer(schema, filter=Condition(lambda: show_schema))]
                        )
                 ]
                ),


### PR DESCRIPTION
- Adds a Ctrl-s Toggle to show/hide the Schema Window
- Moves Schema Window to the right

This PR address the missing part of my #2 by adding a keyboard toggle to show/hide the Schema pane. This also moves the Schema pane as a Horizontal Split of the viewer Pane. The binding I chose is Ctrl-s

I haven't worked with any of these libraries before, and this is just a quick hack to get what I envisioned up and running locally.

Please feel free to reject and use as inspiration for your own implementation, or I'd be happy to take any feedback or changes that would make this acceptable.